### PR TITLE
feat: Implement CRUD for UserBook and ReadingActivity

### DIFF
--- a/app/controllers/reading_activity.controller.go
+++ b/app/controllers/reading_activity.controller.go
@@ -1,13 +1,333 @@
 package controllers
 
-import "gorm.io/gorm"
+import (
+	"ayo-baca-buku/app/models"
+	"ayo-baca-buku/app/util/logger"
+	"strings"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/gofiber/fiber/v2"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
 
 type ReadingActivityController struct {
-	DB *gorm.DB
+	DB       *gorm.DB
+	Validate *validator.Validate
 }
 
 func NewReadingActivityController(DB *gorm.DB) *ReadingActivityController {
 	return &ReadingActivityController{
-		DB: DB,
+		DB:       DB,
+		Validate: validator.New(),
 	}
+}
+
+// CreateReadingActivity godoc
+// @Summary Create a new reading activity
+// @Description Add a new reading activity for a user's book.
+// @Tags ReadingActivity
+// @Accept json
+// @Produce json
+// @Param reading_activity body models.ReadingActivityCreateRequest true "Reading Activity Create Payload"
+// @Success 201 {object} fiber.Map{message=string, data=models.ReadingActivity}
+// @Failure 400 {object} fiber.Map{message=string, errors=map[string]string}
+// @Failure 404 {object} fiber.Map{message=string}
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /reading-activities [post]
+func (c *ReadingActivityController) CreateReadingActivity(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	log.Info("ReadingActivityController.CreateReadingActivity Begin")
+
+	var req models.ReadingActivityCreateRequest
+	if err := ctx.BodyParser(&req); err != nil {
+		log.Error("Failed to parse request body", zap.Error(err))
+		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Invalid Request",
+			"errors":  map[string]string{"body": "Failed to parse request body"},
+		})
+	}
+
+	if err := c.Validate.Struct(&req); err != nil {
+		log.Error("Validation failed for ReadingActivity creation", zap.Error(err))
+		validationErrors := make(map[string]string)
+		for _, vErr := range err.(validator.ValidationErrors) {
+			validationErrors[strings.ToLower(vErr.Field())] = vErr.Error()
+		}
+		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Validation failed",
+			"errors":  validationErrors,
+		})
+	}
+
+	// Verify the UserBook exists
+	var userBook models.UserBook
+	if err := c.DB.First(&userBook, req.UserBookID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			log.Warn("UserBook not found for ReadingActivity creation", zap.Uint("userBookID", req.UserBookID))
+			return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "User book not found"})
+		}
+		log.Error("Failed to check UserBook existence", zap.Error(err), zap.Uint("userBookID", req.UserBookID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"message": "Error checking user book"})
+	}
+
+	// TODO: Authorization check: Does the authenticated user own this UserBook?
+
+	activity := models.ReadingActivity{
+		UserBookID:  req.UserBookID,
+		PagesRead:   req.PagesRead,
+		StartPage:   req.StartPage,
+		EndPage:     req.EndPage,
+		Notes:       req.Notes,
+		ReadingDate: req.ReadingDate,
+	}
+
+	// Use a transaction to ensure both activity creation and book update succeed or fail together.
+	err := c.DB.Transaction(func(tx *gorm.DB) error {
+		// 1. Create the reading activity
+		if err := tx.Create(&activity).Error; err != nil {
+			return err
+		}
+
+		// 2. Update the CurrentPage of the UserBook
+		// We use the EndPage of the activity as the new CurrentPage of the book.
+		// This assumes activities are logged chronologically.
+		if err := tx.Model(&userBook).Update("current_page", activity.EndPage).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Error("Failed to create ReadingActivity and update UserBook", zap.Error(err))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to create reading activity",
+		})
+	}
+
+	log.Info("ReadingActivity created successfully", zap.Uint("activityID", activity.ID))
+	return ctx.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"message": "Reading activity created successfully",
+		"data":    activity,
+	})
+}
+
+// UpdateReadingActivity godoc
+// @Summary Update a specific reading activity
+// @Description Update details of a specific reading activity by its ID.
+// @Tags ReadingActivity
+// @Accept json
+// @Produce json
+// @Param activityId path int true "Reading Activity ID"
+// @Param reading_activity_update body models.ReadingActivityUpdateRequest true "Reading Activity Update Payload"
+// @Success 200 {object} fiber.Map{message=string, data=models.ReadingActivity}
+// @Failure 400 {object} fiber.Map{message=string, errors=map[string]string}
+// @Failure 404 {object} fiber.Map{message=string} "ReadingActivity not found"
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /reading-activities/{activityId} [put]
+func (c *ReadingActivityController) UpdateReadingActivity(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	activityIDStr := ctx.Params("activityId")
+	log.Info("ReadingActivityController.UpdateReadingActivity Begin", zap.String("activityID", activityIDStr))
+
+	var req models.ReadingActivityUpdateRequest
+	if err := ctx.BodyParser(&req); err != nil {
+		log.Error("Failed to parse request body for ReadingActivity update", zap.Error(err))
+		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Invalid Request",
+			"errors":  map[string]string{"body": "Failed to parse request body"},
+		})
+	}
+
+	if err := c.Validate.Struct(&req); err != nil {
+		log.Error("Validation failed for ReadingActivity update", zap.Error(err))
+		validationErrors := make(map[string]string)
+		for _, vErr := range err.(validator.ValidationErrors) {
+			validationErrors[strings.ToLower(vErr.Field())] = vErr.Error()
+		}
+		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Validation failed",
+			"errors":  validationErrors,
+		})
+	}
+
+	var activity models.ReadingActivity
+	if err := c.DB.First(&activity, activityIDStr).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			log.Warn("ReadingActivity not found for update", zap.String("activityID", activityIDStr))
+			return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Reading activity not found"})
+		}
+		log.Error("Failed to fetch ReadingActivity for update", zap.Error(err), zap.String("activityID", activityIDStr))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"message": "Failed to fetch reading activity"})
+	}
+
+	// TODO: Authorization check.
+
+	// Apply updates from request
+	if req.PagesRead != nil {
+		activity.PagesRead = *req.PagesRead
+	}
+	if req.StartPage != nil {
+		activity.StartPage = *req.StartPage
+	}
+	if req.EndPage != nil {
+		activity.EndPage = *req.EndPage
+	}
+	if req.Notes != "" { // Assuming empty string means "not provided"
+		activity.Notes = req.Notes
+	}
+	if !req.ReadingDate.IsZero() {
+		activity.ReadingDate = req.ReadingDate
+	}
+
+	// Note: Updating an activity does not automatically update the UserBook's CurrentPage
+	// as this can have complex side-effects (e.g., if this is not the latest activity).
+	// This would require more complex business logic.
+
+	if err := c.DB.Save(&activity).Error; err != nil {
+		log.Error("Failed to update ReadingActivity in database", zap.Error(err), zap.Uint("activityID", activity.ID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to update reading activity",
+		})
+	}
+
+	log.Info("ReadingActivity updated successfully", zap.Uint("activityID", activity.ID))
+	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{
+		"message": "Reading activity updated successfully",
+		"data":    activity,
+	})
+}
+
+// DeleteReadingActivity godoc
+// @Summary Delete a specific reading activity
+// @Description Permanently delete a specific reading activity by its ID.
+// @Tags ReadingActivity
+// @Accept json
+// @Produce json
+// @Param activityId path int true "Reading Activity ID"
+// @Success 200 {object} fiber.Map{message=string}
+// @Failure 404 {object} fiber.Map{message=string} "ReadingActivity not found"
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /reading-activities/{activityId} [delete]
+func (c *ReadingActivityController) DeleteReadingActivity(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	activityIDStr := ctx.Params("activityId")
+	log.Info("ReadingActivityController.DeleteReadingActivity Begin", zap.String("activityID", activityIDStr))
+
+	var activity models.ReadingActivity
+	if err := c.DB.First(&activity, activityIDStr).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			log.Warn("ReadingActivity not found for deletion", zap.String("activityID", activityIDStr))
+			return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Reading activity not found"})
+		}
+		log.Error("Failed to fetch ReadingActivity for deletion", zap.Error(err), zap.String("activityID", activityIDStr))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"message": "Failed to fetch reading activity"})
+	}
+
+	// TODO: Authorization check.
+
+	// Perform hard delete
+	if err := c.DB.Unscoped().Delete(&activity).Error; err != nil {
+		log.Error("Failed to delete ReadingActivity from database", zap.Error(err), zap.Uint("activityID", activity.ID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to delete reading activity",
+		})
+	}
+
+	// Note: Deleting an activity does not automatically adjust the UserBook's CurrentPage.
+
+	log.Info("ReadingActivity deleted successfully", zap.Uint("activityID", activity.ID))
+	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{"message": "Reading activity deleted successfully"})
+}
+
+// GetAllReadingActivitiesForUserBook godoc
+// @Summary Get all reading activities for a specific user book
+// @Description Retrieve a list of all reading activities associated with a given UserBook ID.
+// @Tags ReadingActivity
+// @Accept json
+// @Produce json
+// @Param userBookId path int true "UserBook ID"
+// @Success 200 {object} fiber.Map{message=string, data=[]models.ReadingActivity}
+// @Failure 404 {object} fiber.Map{message=string} "UserBook not found"
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /userbooks/{userBookId}/activities [get]
+func (c *ReadingActivityController) GetAllReadingActivitiesForUserBook(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	userBookIDStr := ctx.Params("userBookId")
+	log.Info("ReadingActivityController.GetAllReadingActivitiesForUserBook Begin", zap.String("userBookID", userBookIDStr))
+
+	// Validate UserBookID exists
+	var userBook models.UserBook
+	if err := c.DB.First(&userBook, userBookIDStr).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			log.Warn("UserBook not found when listing activities", zap.String("userBookID", userBookIDStr))
+			return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "User book not found"})
+		}
+		log.Error("Failed to verify UserBook existence for listing activities", zap.Error(err), zap.String("userBookID", userBookIDStr))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"message": "Error verifying user book"})
+	}
+
+	// TODO: Authorization check: Does the authenticated user own this UserBook?
+
+	var activities []models.ReadingActivity
+	if err := c.DB.Where("user_book_id = ?", userBook.ID).Order("reading_date DESC, created_at DESC").Find(&activities).Error; err != nil {
+		log.Error("Failed to fetch reading activities from database", zap.Error(err), zap.Uint("userBookID", userBook.ID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to fetch reading activities",
+		})
+	}
+
+	log.Info("Reading activities fetched successfully for UserBook", zap.Uint("userBookID", userBook.ID), zap.Int("count", len(activities)))
+	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{
+		"message": "Reading activities fetched successfully",
+		"data":    activities,
+	})
+}
+
+// GetReadingActivityByID godoc
+// @Summary Get a specific reading activity by its ID
+// @Description Retrieve details of a specific reading activity by its ID.
+// @Tags ReadingActivity
+// @Accept json
+// @Produce json
+// @Param activityId path int true "Reading Activity ID"
+// @Success 200 {object} fiber.Map{message=string, data=models.ReadingActivity}
+// @Failure 404 {object} fiber.Map{message=string} "ReadingActivity not found"
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /reading-activities/{activityId} [get]
+func (c *ReadingActivityController) GetReadingActivityByID(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	activityIDStr := ctx.Params("activityId")
+	log.Info("ReadingActivityController.GetReadingActivityByID Begin", zap.String("activityID", activityIDStr))
+
+	var activity models.ReadingActivity
+	// Preload UserBook to provide context.
+	if err := c.DB.Preload("UserBook").First(&activity, activityIDStr).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			log.Warn("ReadingActivity not found by ID", zap.String("activityID", activityIDStr))
+			return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Reading activity not found"})
+		}
+		log.Error("Failed to fetch ReadingActivity by ID from database", zap.Error(err), zap.String("activityID", activityIDStr))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to fetch reading activity",
+		})
+	}
+
+	// TODO: Authorization check: Does the authenticated user own the UserBook associated with this activity?
+	// For example, after fetching activity:
+	// var userBook models.UserBook
+	// if err := c.DB.First(&userBook, activity.UserBookID).Error; err == nil {
+	//   if authenticatedUserID != userBook.UserID && !IsAdmin(authenticatedUser) {
+	//     return ctx.Status(fiber.StatusForbidden).JSON(...)
+	//   }
+	// } else { /* handle error fetching userbook for auth check */ }
+
+
+	log.Info("ReadingActivity fetched successfully by ID", zap.Uint("activityID", activity.ID))
+	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{
+		"message": "Reading activity fetched successfully",
+		"data":    activity,
+	})
 }

--- a/app/controllers/user_book.controller.go
+++ b/app/controllers/user_book.controller.go
@@ -1,13 +1,357 @@
 package controllers
 
-import "gorm.io/gorm"
+import (
+	"ayo-baca-buku/app/models"
+	"ayo-baca-buku/app/util/logger"
+	"ayo-baca-buku/app/util/validation" // Assuming validation utilities might be needed
+	"strings"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/gofiber/fiber/v2"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
 
 type UserBookController struct {
-	DB *gorm.DB
+	DB       *gorm.DB
+	Validate *validator.Validate
 }
 
 func NewUserBookController(DB *gorm.DB) *UserBookController {
 	return &UserBookController{
-		DB: DB,
+		DB:       DB,
+		Validate: validator.New(),
 	}
+}
+
+// CreateUserBook godoc
+// @Summary Create a new user book entry
+// @Description Add a new book to a user's reading list.
+// @Tags UserBook
+// @Accept json
+// @Produce json
+// @Param userbook body models.UserBookCreateRequest true "User Book Create Payload"
+// @Success 201 {object} fiber.Map{message=string, data=models.UserBook}
+// @Failure 400 {object} fiber.Map{message=string, errors=map[string]string}
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /userbooks [post]
+func (c *UserBookController) CreateUserBook(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	log.Info("UserBookController.CreateUserBook Begin")
+
+	var req models.UserBookCreateRequest
+	if err := ctx.BodyParser(&req); err != nil {
+		log.Error("Failed to parse request body", zap.Error(err))
+		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Invalid Request",
+			"errors":  map[string]string{"body": "Failed to parse request body"},
+		})
+	}
+
+	// TODO: In a real app, UserID might come from JWT token/auth context.
+	// For now, it's in the request. We should validate if this user exists.
+	var user models.User
+	if err := c.DB.First(&user, req.UserID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			log.Warn("User not found for UserBook creation", zap.Uint("userID", req.UserID))
+			return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"message": "Validation failed",
+				"errors":  map[string]string{"user_id": "User not found"},
+			})
+		}
+		log.Error("Failed to check user existence", zap.Error(err), zap.Uint("userID", req.UserID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"message": "Error checking user"})
+	}
+
+	// Initialize validator (could be part of controller struct if reused often without per-handler registration)
+	// c.Validate.RegisterValidation("custom_validation_if_any", validation.CustomValidationFunction(c.DB))
+	if err := c.Validate.Struct(&req); err != nil {
+		log.Error("Validation failed for UserBook creation", zap.Error(err))
+		validationErrors := make(map[string]string)
+		for _, vErr := range err.(validator.ValidationErrors) {
+			validationErrors[strings.ToLower(vErr.Field())] = vErr.Error()
+		}
+		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Validation failed",
+			"errors":  validationErrors,
+		})
+	}
+
+	userBook := models.UserBook{
+		UserID:         req.UserID,
+		Title:          req.Title,
+		Author:         req.Author,
+		Publisher:      req.Publisher,
+		Cover:          req.Cover,
+		TotalPages:     req.TotalPages,
+		MotivationRead: req.MotivationRead,
+		Status:         "reading", // Default status
+		StartDate:      req.StartDate,
+		// EndDate will be null initially
+		CurrentPage: 0, // Default current page
+		CreatedBy:   int64(req.UserID), // Placeholder for actor ID
+		UpdatedBy:   int64(req.UserID), // Placeholder for actor ID
+	}
+
+	if err := c.DB.Create(&userBook).Error; err != nil {
+		log.Error("Failed to create UserBook in database", zap.Error(err))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to create user book entry",
+		})
+	}
+
+	log.Info("UserBook created successfully", zap.Uint("userBookID", userBook.ID))
+	return ctx.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"message": "User book entry created successfully",
+		"data":    userBook,
+	})
+}
+
+// UpdateUserBook godoc
+// @Summary Update an existing user book
+// @Description Update details of an existing user book by its ID.
+// @Tags UserBook
+// @Accept json
+// @Produce json
+// @Param id path int true "UserBook ID"
+// @Param userbook_update body models.UserBookUpdateRequest true "User Book Update Payload"
+// @Success 200 {object} fiber.Map{message=string, data=models.UserBook}
+// @Failure 400 {object} fiber.Map{message=string, errors=map[string]string}
+// @Failure 404 {object} fiber.Map{message=string}
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /userbooks/{id} [put]
+func (c *UserBookController) UpdateUserBook(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	userBookID := ctx.Params("id")
+	log.Info("UserBookController.UpdateUserBook Begin", zap.String("userBookID", userBookID))
+
+	var req models.UserBookUpdateRequest
+	if err := ctx.BodyParser(&req); err != nil {
+		log.Error("Failed to parse request body for UserBook update", zap.Error(err))
+		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Invalid Request",
+			"errors":  map[string]string{"body": "Failed to parse request body"},
+		})
+	}
+
+	// Validate the request payload
+	if err := c.Validate.Struct(&req); err != nil {
+		log.Error("Validation failed for UserBook update", zap.Error(err))
+		validationErrors := make(map[string]string)
+		for _, vErr := range err.(validator.ValidationErrors) {
+			validationErrors[strings.ToLower(vErr.Field())] = vErr.Error()
+		}
+		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Validation failed",
+			"errors":  validationErrors,
+		})
+	}
+
+	var userBook models.UserBook
+	if err := c.DB.First(&userBook, userBookID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			log.Warn("UserBook not found for update", zap.String("userBookID", userBookID))
+			return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "User book not found"})
+		}
+		log.Error("Failed to fetch UserBook for update", zap.Error(err), zap.String("userBookID", userBookID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"message": "Failed to fetch user book"})
+	}
+
+	// TODO: Authorization check: Does the authenticated user own this book or have rights to update it?
+	// For example: if authenticatedUserID != userBook.UserID && !isAdmin(authenticatedUser) { return ctx.Status(fiber.StatusForbidden).JSON(...) }
+	// For now, assume actorID for UpdatedBy can be derived or is a placeholder
+	actorID := userBook.UserID // Placeholder for who is performing the update
+
+	// Apply updates from request
+	if req.Title != "" {
+		userBook.Title = req.Title
+	}
+	if req.Author != "" {
+		userBook.Author = req.Author
+	}
+	if req.Publisher != "" { // omitempty means empty string is a valid "not provided"
+		userBook.Publisher = req.Publisher
+	}
+	if req.Cover != "" { // omitempty means empty string is a valid "not provided"
+		userBook.Cover = req.Cover
+	}
+	if req.TotalPages != nil {
+		userBook.TotalPages = *req.TotalPages
+	}
+	if req.CurrentPage != nil {
+		userBook.CurrentPage = *req.CurrentPage
+	}
+	if req.MotivationRead != "" { // omitempty means empty string is a valid "not provided"
+		userBook.MotivationRead = req.MotivationRead
+	}
+	if req.Status != "" {
+		userBook.Status = req.Status
+	}
+	if !req.StartDate.IsZero() { // Check if StartDate is provided (not its zero value)
+		userBook.StartDate = req.StartDate
+	}
+	if !req.EndDate.IsZero() { // Check if EndDate is provided
+		userBook.EndDate = req.EndDate
+	} else if req.Status == "finished" && userBook.EndDate.IsZero() {
+		// If status is marked 'finished' and EndDate was not explicitly set, set it to now.
+		userBook.EndDate = time.Now()
+	}
+
+
+	userBook.UpdatedBy = int64(actorID) // Placeholder
+
+	if err := c.DB.Save(&userBook).Error; err != nil {
+		log.Error("Failed to update UserBook in database", zap.Error(err), zap.Uint("userBookID", userBook.ID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to update user book entry",
+		})
+	}
+
+	log.Info("UserBook updated successfully", zap.Uint("userBookID", userBook.ID))
+	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{
+		"message": "User book entry updated successfully",
+		"data":    userBook,
+	})
+}
+
+// DeleteUserBook godoc
+// @Summary Soft delete a user book
+// @Description Soft delete a user book by its ID.
+// @Tags UserBook
+// @Accept json
+// @Produce json
+// @Param id path int true "UserBook ID"
+// @Success 200 {object} fiber.Map{message=string}
+// @Failure 403 {object} fiber.Map{message=string} // Forbidden if user doesn't own the book
+// @Failure 404 {object} fiber.Map{message=string}
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /userbooks/{id} [delete]
+func (c *UserBookController) DeleteUserBook(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	userBookID := ctx.Params("id")
+	log.Info("UserBookController.DeleteUserBook Begin", zap.String("userBookID", userBookID))
+
+	var userBook models.UserBook
+	if err := c.DB.First(&userBook, userBookID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			log.Warn("UserBook not found for deletion", zap.String("userBookID", userBookID))
+			return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "User book not found"})
+		}
+		log.Error("Failed to fetch UserBook for deletion", zap.Error(err), zap.String("userBookID", userBookID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"message": "Failed to fetch user book"})
+	}
+
+	// TODO: Authorization check: Does the authenticated user own this book or have rights to delete it?
+	// For example:
+	// authenticatedUserID := GetAuthenticatedUserID(ctx) // Implement this helper
+	// if authenticatedUserID != userBook.UserID && !IsAdmin(authenticatedUserID) {
+	//     log.Warn("User not authorized to delete UserBook", zap.Uint("userBookID", userBook.ID), zap.Uint("attemptedByUserID", authenticatedUserID))
+	//     return ctx.Status(fiber.StatusForbidden).JSON(fiber.Map{"message": "You are not authorized to delete this book entry"})
+	// }
+	actorID := userBook.UserID // Placeholder for who is performing the delete
+
+	// Update DeletedBy before soft deleting
+	// GORM's Delete will set DeletedAt automatically
+	if err := c.DB.Model(&userBook).Update("DeletedBy", int64(actorID)).Error; err != nil {
+		// Log the error but proceed with delete, as setting DeletedBy is audit info.
+		// Depending on requirements, this could be a critical failure.
+		log.Error("Failed to update DeletedBy for UserBook soft delete", zap.Error(err), zap.Uint("userBookID", userBook.ID))
+	}
+
+	if err := c.DB.Delete(&userBook).Error; err != nil {
+		log.Error("Failed to soft delete UserBook in database", zap.Error(err), zap.Uint("userBookID", userBook.ID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to delete user book entry",
+		})
+	}
+
+	log.Info("UserBook soft deleted successfully", zap.Uint("userBookID", userBook.ID))
+	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{"message": "User book entry deleted successfully"})
+}
+
+// GetAllUserBooks godoc
+// @Summary Get all user books
+// @Description Get a list of all user books, optionally filtered by user_id.
+// @Tags UserBook
+// @Accept json
+// @Produce json
+// @Param user_id query int false "Filter by User ID"
+// @Success 200 {object} fiber.Map{message=string, data=[]models.UserBook}
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /userbooks [get]
+func (c *UserBookController) GetAllUserBooks(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	log.Info("UserBookController.GetAllUserBooks Begin")
+
+	var userBooks []models.UserBook
+	query := c.DB
+
+	// Optional filtering by user_id
+	userID := ctx.QueryInt("user_id")
+	if userID > 0 {
+		log.Info("Filtering UserBooks by UserID", zap.Int("userID", userID))
+		query = query.Where("user_id = ?", userID)
+	}
+
+	// Preload ReadingActivities and User for richer data. Consider if this is always needed.
+	// For now, let's preload User to show who the book belongs to if not filtering.
+	// ReadingActivities might be too much for a general list, better for GetUserBookByID.
+	if err := query.Preload("User").Find(&userBooks).Error; err != nil {
+		log.Error("Failed to fetch user books from database", zap.Error(err))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to fetch user books",
+		})
+	}
+
+	log.Info("UserBooks fetched successfully", zap.Int("count", len(userBooks)))
+	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{
+		"message": "User books fetched successfully",
+		"data":    userBooks,
+	})
+}
+
+// GetUserBookByID godoc
+// @Summary Get a user book by its ID
+// @Description Get details of a specific user book, including its owner and reading activities.
+// @Tags UserBook
+// @Accept json
+// @Produce json
+// @Param id path int true "UserBook ID"
+// @Success 200 {object} fiber.Map{message=string, data=models.UserBook}
+// @Failure 404 {object} fiber.Map{message=string}
+// @Failure 500 {object} fiber.Map{message=string}
+// @Router /userbooks/{id} [get]
+func (c *UserBookController) GetUserBookByID(ctx *fiber.Ctx) error {
+	log := logger.GetLogger()
+	userBookID := ctx.Params("id") // This will be a string, needs conversion if your ID is int
+	log.Info("UserBookController.GetUserBookByID Begin", zap.String("userBookID", userBookID))
+
+	var userBook models.UserBook
+
+	// Preload User and ReadingActivities for detailed view
+	// Convert userBookID to appropriate type for GORM if necessary (e.g., to uint)
+	// For now, GORM might handle string-to-int conversion for primary keys, but being explicit is better.
+	// Let's assume ID in path is parseable to uint for the model's ID type.
+	if err := c.DB.Preload("User").Preload("ReadingActivities").First(&userBook, userBookID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			log.Warn("UserBook not found by ID", zap.String("userBookID", userBookID))
+			return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"message": "User book not found",
+			})
+		}
+		log.Error("Failed to fetch UserBook by ID from database", zap.Error(err), zap.String("userBookID", userBookID))
+		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"message": "Failed to fetch user book",
+		})
+	}
+
+	// TODO: Authorization check: Does the authenticated user own this book or have rights to view it?
+	// For example: if authenticatedUserID != userBook.UserID && !isAdmin(authenticatedUser) { return ctx.Status(fiber.StatusForbidden).JSON(...) }
+
+	log.Info("UserBook fetched successfully by ID", zap.Uint("userBookID", userBook.ID))
+	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{
+		"message": "User book fetched successfully",
+		"data":    userBook,
+	})
 }

--- a/app/models/reading_activity.model.go
+++ b/app/models/reading_activity.model.go
@@ -17,5 +17,24 @@ type ReadingActivity struct {
 	UserBook    UserBook       `json:"user_book" gorm:"foreignKey:UserBookID"`
 	CreatedAt   time.Time      `json:"created_at"`
 	UpdatedAt   time.Time      `json:"updated_at"`
-	DeletedAt   gorm.DeletedAt `json:"deleted_at" gorm:"index"`
+	DeletedAt   gorm.DeletedAt `json:"deleted_at,omitempty" gorm:"index"`
+}
+
+// ReadingActivityCreateRequest defines the payload for creating a reading activity.
+type ReadingActivityCreateRequest struct {
+	UserBookID  uint      `json:"user_book_id" validate:"required"`
+	PagesRead   int       `json:"pages_read" validate:"required,gt=0"`
+	StartPage   int       `json:"start_page" validate:"required,gte=0"`
+	EndPage     int       `json:"end_page" validate:"required,gtfield=StartPage"`
+	Notes       string    `json:"notes,omitempty"`
+	ReadingDate time.Time `json:"reading_date" validate:"required"`
+}
+
+// ReadingActivityUpdateRequest defines the payload for updating a reading activity.
+type ReadingActivityUpdateRequest struct {
+	PagesRead   *int      `json:"pages_read,omitempty" validate:"omitempty,gt=0"`
+	StartPage   *int      `json:"start_page,omitempty" validate:"omitempty,gte=0"`
+	EndPage     *int      `json:"end_page,omitempty" validate:"omitempty,gtfield=StartPage"`
+	Notes       string    `json:"notes,omitempty"`
+	ReadingDate time.Time `json:"reading_date,omitempty" validate:"omitempty,required"`
 }

--- a/app/models/user_book.model.go
+++ b/app/models/user_book.model.go
@@ -25,6 +25,34 @@ type UserBook struct {
 	CreatedBy         int64             `json:"created_by"`
 	UpdatedAt         time.Time         `json:"updated_at"`
 	UpdatedBy         int64             `json:"updated_by"`
-	DeletedAt         gorm.DeletedAt    `json:"deleted_at" gorm:"index"`
-	DeletedBy         int64             `json:"deleted_by"`
+	DeletedAt         gorm.DeletedAt    `json:"deleted_at,omitempty" gorm:"index"`
+	DeletedBy         int64             `json:"deleted_by,omitempty"`
+}
+
+// UserBookCreateRequest defines the structure for creating a new user book.
+// UserID would typically come from the authenticated user context in a real app.
+type UserBookCreateRequest struct {
+	UserID         uint      `json:"user_id" validate:"required"`
+	Title          string    `json:"title" validate:"required,min=1,max=255"`
+	Author         string    `json:"author" validate:"required,min=1,max=255"`
+	Publisher      string    `json:"publisher,omitempty" validate:"omitempty,max=255"`
+	Cover          string    `json:"cover,omitempty" validate:"omitempty,url,max=255"`
+	TotalPages     int       `json:"total_pages" validate:"required,gt=0"`
+	MotivationRead string    `json:"motivation_read,omitempty"`
+	StartDate      time.Time `json:"start_date" validate:"required"`
+	// Status will default to 'reading' in the model or controller
+}
+
+// UserBookUpdateRequest defines the structure for updating an existing user book.
+type UserBookUpdateRequest struct {
+	Title          string    `json:"title,omitempty" validate:"omitempty,min=1,max=255"`
+	Author         string    `json:"author,omitempty" validate:"omitempty,min=1,max=255"`
+	Publisher      string    `json:"publisher,omitempty" validate:"omitempty,max=255"`
+	Cover          string    `json:"cover,omitempty" validate:"omitempty,url,max=255"`
+	TotalPages     *int      `json:"total_pages,omitempty" validate:"omitempty,gt=0"` // Pointer to distinguish between 0 and not provided
+	CurrentPage    *int      `json:"current_page,omitempty" validate:"omitempty,gte=0"`
+	MotivationRead string    `json:"motivation_read,omitempty"`
+	Status         string    `json:"status,omitempty" validate:"omitempty,oneof=reading finished"`
+	StartDate      time.Time `json:"start_date,omitempty" validate:"omitempty,required"` // omitempty might not be ideal if you want to clear it, but for time.Time zero value is tricky.
+	EndDate        time.Time `json:"end_date,omitempty"`                                 // omitempty is fine here. Consider *time.Time if clearing is needed and zero value is significant.
 }

--- a/app/routes/reading_activity.route.go
+++ b/app/routes/reading_activity.route.go
@@ -1,0 +1,33 @@
+package routes
+
+import (
+	"ayo-baca-buku/app/controllers"
+	// "ayo-baca-buku/app/middlewares" // Placeholder for auth middleware
+
+	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
+)
+
+func SetupReadingActivityRoutes(app *fiber.App, DB *gorm.DB) {
+	// Instantiate the ReadingActivityController
+	readingActivityController := controllers.NewReadingActivityController(DB)
+
+	// Group for activities related to a specific user book
+	// This route is for listing activities for a specific book
+	userBookActivitiesRoutes := app.Group("/userbooks/:userBookId/activities")
+	// Apply middleware here if needed, e.g., middlewares.AuthJWTMiddleware()
+	userBookActivitiesRoutes.Get("/", readingActivityController.GetAllReadingActivitiesForUserBook)
+	// Note: CreateReadingActivity currently expects UserBookID in the body.
+	// A more RESTful approach for creation might be POST to this grouped route,
+	// requiring controller adjustment to take UserBookID from path.
+	// For now, Create will be a top-level route as per current controller design.
+
+	// Group for general reading activity management (by activity ID)
+	// Apply middleware here if needed
+	activityRoutes := app.Group("/reading-activities")
+
+	activityRoutes.Post("/", readingActivityController.CreateReadingActivity) // UserBookID in body
+	activityRoutes.Get("/:activityId", readingActivityController.GetReadingActivityByID)
+	activityRoutes.Put("/:activityId", readingActivityController.UpdateReadingActivity)
+	activityRoutes.Delete("/:activityId", readingActivityController.DeleteReadingActivity)
+}

--- a/app/routes/user_book.route.go
+++ b/app/routes/user_book.route.go
@@ -1,18 +1,24 @@
 package routes
 
 import (
-	"github.com/go-playground/validator/v10"
+	"ayo-baca-buku/app/controllers" // Import the actual controllers package
+	// "ayo-baca-buku/app/middlewares" // Placeholder for auth middleware if needed
+
+	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
 )
 
-type UserBookController struct {
-	DB       *gorm.DB
-	Validate *validator.Validate
-}
+func SetupUserBookRoutes(app *fiber.App, DB *gorm.DB) {
+	// Instantiate the actual UserBookController
+	userBookController := controllers.NewUserBookController(DB)
 
-func NewUserBookController(DB *gorm.DB) *UserBookController {
-	return &UserBookController{
-		DB:       DB,
-		Validate: validator.New(),
-	}
+	// Group routes for /userbooks
+	// Apply middleware here if needed, e.g., middlewares.AuthJWTMiddleware()
+	userBookRoutes := app.Group("/userbooks")
+
+	userBookRoutes.Post("/", userBookController.CreateUserBook)
+	userBookRoutes.Get("/", userBookController.GetAllUserBooks)
+	userBookRoutes.Get("/:id", userBookController.GetUserBookByID)
+	userBookRoutes.Put("/:id", userBookController.UpdateUserBook)
+	userBookRoutes.Delete("/:id", userBookController.DeleteUserBook) // Soft delete
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,6 +71,8 @@ func main() {
 
 	routes.SetupAuthRoutes(app, DB)
 	routes.SetupUserRoutes(app, DB)
+	routes.SetupUserBookRoutes(app, DB) // Added UserBook routes
+	routes.SetupReadingActivityRoutes(app, DB) // Added ReadingActivity routes
 
 	go func() {
 		// Memberikan sedikit jeda untuk memastikan server sudah berjalan


### PR DESCRIPTION
I've implemented full CRUD operations for UserBook, including models for create/update requests, controller logic, and routes.

I've also implemented full CRUD operations for ReadingActivity, including:
- Models for create/update requests.
- Controller logic with a transaction for creating an activity and updating UserBook's current page.
- Routes for managing activities, including listing activities for a specific UserBook.

I added Swagger GoDoc annotations to all new controller methods for both UserBook and ReadingActivity.

I skipped the `swag init` command execution as you requested (to be handled manually).